### PR TITLE
Propagate errors in EventType function

### DIFF
--- a/golang/pkg/events/events.go
+++ b/golang/pkg/events/events.go
@@ -52,12 +52,12 @@ func EventType(src []byte) (string, error) {
 	var decodedCe CloudEvent
 	err := proto.Unmarshal(src, &decodedCe)
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	any, err := anypb.UnmarshalNew(decodedCe.GetProtoData(), proto.UnmarshalOptions{})
 	if err != nil {
-		return "", nil
+		return "", err
 	}
 
 	name := any.ProtoReflect().Type().Descriptor().FullName()


### PR DESCRIPTION
Simply propagate the errors to use them in the agent code