### PR TITLE
Add timestamp to elixir cloudevent envelope

### DIFF
--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -14,6 +14,14 @@ defmodule Trento.Contracts do
   def to_event(%mod{} = struct, opts \\ []) do
     id = Keyword.get(opts, :id, UUID.uuid4())
     source = Keyword.get(opts, :source, "trento")
+
+    time =
+      Keyword.get(
+        opts,
+        :time,
+        Google.Protobuf.Timestamp.new(seconds: System.system_time(:second))
+      )
+
     data = Protobuf.Encoder.encode(struct)
 
     cloud_event =
@@ -22,6 +30,9 @@ defmodule Trento.Contracts do
         spec_version: "1.0",
         type: get_type(mod),
         id: id,
+        attributes: %{
+          "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time})
+        },
         source: source
       )
 

--- a/elixir/lib/contracts.ex
+++ b/elixir/lib/contracts.ex
@@ -19,9 +19,10 @@ defmodule Trento.Contracts do
       Keyword.get(
         opts,
         :time,
-        Google.Protobuf.Timestamp.new(seconds: System.system_time(:second))
+        DateTime.utc_now()
       )
 
+    time_attr = Google.Protobuf.Timestamp.new!(seconds: time |> DateTime.to_unix())
     data = Protobuf.Encoder.encode(struct)
 
     cloud_event =
@@ -31,7 +32,7 @@ defmodule Trento.Contracts do
         type: get_type(mod),
         id: id,
         attributes: %{
-          "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time})
+          "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time_attr})
         },
         source: source
       )

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -28,7 +28,8 @@ defmodule Trento.ContractsTest do
   test "should encode to the right struct" do
     event = Test.Event.new(id: UUID.uuid4())
     cloudevent_id = UUID.uuid4()
-    time = Google.Protobuf.Timestamp.new(seconds: 1000)
+    time = DateTime.utc_now()
+    time_attr = Google.Protobuf.Timestamp.new!(seconds: time |> DateTime.to_unix())
 
     cloudevent = %CloudEvent{
       data:
@@ -43,7 +44,7 @@ defmodule Trento.ContractsTest do
       spec_version: "1.0",
       type: "Test.Event",
       attributes: %{
-        "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time})
+        "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time_attr})
       }
     }
 

--- a/elixir/test/contracts_test.exs
+++ b/elixir/test/contracts_test.exs
@@ -28,6 +28,7 @@ defmodule Trento.ContractsTest do
   test "should encode to the right struct" do
     event = Test.Event.new(id: UUID.uuid4())
     cloudevent_id = UUID.uuid4()
+    time = Google.Protobuf.Timestamp.new(seconds: 1000)
 
     cloudevent = %CloudEvent{
       data:
@@ -40,12 +41,20 @@ defmodule Trento.ContractsTest do
       id: cloudevent_id,
       source: "wandalorian",
       spec_version: "1.0",
-      type: "Test.Event"
+      type: "Test.Event",
+      attributes: %{
+        "time" => CloudEvents.CloudEventAttributeValue.new!(attr: {:ce_timestamp, time})
+      }
     }
 
     encoded_cloudevent = CloudEvent.encode(cloudevent)
 
-    assert encoded_cloudevent == Trento.Contracts.to_event(event, id: cloudevent_id, source: "wandalorian")
+    assert encoded_cloudevent ==
+             Trento.Contracts.to_event(event,
+               id: cloudevent_id,
+               source: "wandalorian",
+               time: time
+             )
   end
 
   test "should return error if the event is not wrapped in a CloudEvent" do
@@ -75,6 +84,7 @@ defmodule Trento.ContractsTest do
       type: "Unknown.Event"
     }
 
-    assert {:error, :unknown_event} = cloudevent |> CloudEvent.encode() |> Trento.Contracts.from_event()
+    assert {:error, :unknown_event} =
+             cloudevent |> CloudEvent.encode() |> Trento.Contracts.from_event()
   end
 end


### PR DESCRIPTION
This PR adds the `ce_timestamp` attribute to the cloudevents envelope on the elixir part.

Go part coming next.