### PR TITLE
Add timestamp cloudevent go

### DIFF
--- a/golang/go.mod
+++ b/golang/go.mod
@@ -9,6 +9,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/uuid v1.3.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/golang/go.sum
+++ b/golang/go.sum
@@ -4,6 +4,8 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
+github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/golang/pkg/events/events.go
+++ b/golang/pkg/events/events.go
@@ -17,7 +17,7 @@ type cloudEventOptions struct {
 
 type Option = func(fields *cloudEventOptions)
 
-func WithId(id *string) Option {
+func WithID(id *string) Option {
 	return func(fields *cloudEventOptions) {
 		fields.id = id
 	}

--- a/golang/pkg/events/events_test.go
+++ b/golang/pkg/events/events_test.go
@@ -65,6 +65,29 @@ func TestToEvent(t *testing.T) {
 	assert.EqualValues(t, rawCe, encodedEvent)
 }
 
+func TestToEventWithDefaults(t *testing.T) {
+	event := events.FactsGatheringRequested{
+		ExecutionId: "exe",
+		GroupId:     "group_1",
+		Targets: []*events.FactsGatheringRequestedTarget{
+			{
+				AgentId: "agent_1",
+				FactRequests: []*events.FactRequest{
+					{
+						CheckId:  "check_1",
+						Name:     "test fact",
+						Gatherer: "factone",
+						Argument: "arg",
+					},
+				},
+			},
+		},
+	}
+
+	_, err := events.ToEvent(&event)
+	assert.NoError(t, err)
+}
+
 func TestFromEvent(t *testing.T) {
 	event := events.FactsGatheringRequested{
 		ExecutionId: "exe",

--- a/golang/pkg/events/events_test.go
+++ b/golang/pkg/events/events_test.go
@@ -29,6 +29,7 @@ func TestToEvent(t *testing.T) {
 			},
 		},
 	}
+
 	id := "id"
 	source := "wandalorian"
 	time := time.Now()
@@ -58,7 +59,7 @@ func TestToEvent(t *testing.T) {
 	rawCe, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
 
-	encodedEvent, err := events.ToEvent(&event, id, source, events.WithTime(&time))
+	encodedEvent, err := events.ToEvent(&event, events.WithId(&id), events.WithSource(&source), events.WithTime(&time))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, rawCe, encodedEvent)

--- a/golang/pkg/events/events_test.go
+++ b/golang/pkg/events/events_test.go
@@ -59,7 +59,7 @@ func TestToEvent(t *testing.T) {
 	rawCe, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
 
-	encodedEvent, err := events.ToEvent(&event, events.WithID(&id), events.WithSource(&source), events.WithTime(&time))
+	encodedEvent, err := events.ToEvent(&event, events.WithID(id), events.WithSource(source), events.WithTime(time))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, rawCe, encodedEvent)

--- a/golang/pkg/events/events_test.go
+++ b/golang/pkg/events/events_test.go
@@ -2,6 +2,7 @@ package events_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/trento-project/contracts/pkg/events"
@@ -28,25 +29,22 @@ func TestToEvent(t *testing.T) {
 			},
 		},
 	}
-
-	opts := events.CloudEventOptions{
-		Id:     "id",
-		Source: "wandalorian",
-		Time:   timestamppb.Now(),
-	}
+	id := "id"
+	source := "wandalorian"
+	time := time.Now()
 
 	data, err := anypb.New(&event)
 
 	attr := events.CloudEventAttributeValue{
 		Attr: &events.CloudEventAttributeValue_CeTimestamp{
-			CeTimestamp: opts.Time,
+			CeTimestamp: timestamppb.New(time),
 		},
 	}
 
 	assert.NoError(t, err)
 	ce := events.CloudEvent{
-		Id:          opts.Id,
-		Source:      opts.Source,
+		Id:          id,
+		Source:      source,
 		SpecVersion: "1.0",
 		Type:        string(event.ProtoReflect().Descriptor().FullName()),
 		Data: &events.CloudEvent_ProtoData{
@@ -60,7 +58,7 @@ func TestToEvent(t *testing.T) {
 	rawCe, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
 
-	encodedEvent, err := events.ToEvent(&event, opts)
+	encodedEvent, err := events.ToEvent(&event, id, source, events.WithTime(&time))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, rawCe, encodedEvent)

--- a/golang/pkg/events/events_test.go
+++ b/golang/pkg/events/events_test.go
@@ -59,7 +59,7 @@ func TestToEvent(t *testing.T) {
 	rawCe, err := proto.Marshal(&ce)
 	assert.NoError(t, err)
 
-	encodedEvent, err := events.ToEvent(&event, events.WithId(&id), events.WithSource(&source), events.WithTime(&time))
+	encodedEvent, err := events.ToEvent(&event, events.WithID(&id), events.WithSource(&source), events.WithTime(&time))
 	assert.NoError(t, err)
 
 	assert.EqualValues(t, rawCe, encodedEvent)


### PR DESCRIPTION
This PR adds the a timestamp attribute to the cloudevents envelope on the go part.
